### PR TITLE
Create UnArchive transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 hs_err_pid*
 target
 .okhttpcache
+/.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM maven:3-openjdk-8-slim AS BUILD_CONNECT_TRANSFORM_ARCHIVE_PLUGIN
+WORKDIR /tmp
+RUN apt-get update && apt-get install -y git
+COPY . /tmp/kafka-connect-transform-archive
+RUN cd kafka-connect-transform-archive && mvn package

--- a/README.md
+++ b/README.md
@@ -28,11 +28,18 @@ This transform works by copying the key, value, topic, and timestamp to new reco
 This configuration is used typically along with [standalone mode](http://docs.confluent.io/current/connect/concepts.html#standalone-workers).
 
 ```properties
+# Archive
 name=Connector1
 connector.class=org.apache.kafka.some.SourceConnector
 tasks.max=1
 transforms=tran
 transforms.tran.type=com.github.jcustenborder.kafka.connect.archive.Archive
+# Unarchive
+name=Connector1
+connector.class=org.apache.kafka.some.SourceConnector
+tasks.max=1
+transforms=tran
+transforms.tran.type=com.github.jcustenborder.kafka.connect.archive.UnArchive
 ```
 
 ##### Distributed Example
@@ -42,11 +49,19 @@ Write the following json to `connector.json`, configure all of the required valu
 post the configuration to one the distributed connect worker(s).
 
 ```json
+// Archive
 {
   "name" : "Connector1",
   "connector.class" : "org.apache.kafka.some.SourceConnector",
   "transforms" : "tran",
   "transforms.tran.type" : "com.github.jcustenborder.kafka.connect.archive.Archive"
+}
+// UnArchive
+{
+  "name" : "Connector1",
+  "connector.class" : "org.apache.kafka.some.SourceConnector",
+  "transforms" : "tran",
+  "transforms.tran.type" : "com.github.jcustenborder.kafka.connect.archive.UnArchive"
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,11 +74,6 @@
       <version>[0.2.33,0.2.1000)</version>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-          <version>2.9.0</version>
-      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,21 @@
     <system>github</system>
     <url>https://github.com/jcustenborder/kafka-connect-transform-archive/issues</url>
   </issueManagement>
+  <properties>
+      <connect.api.version>3.0.0</connect.api.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.github.jcustenborder</groupId>
       <artifactId>cef-parser</artifactId>
       <version>[0.0.1.7,0.0.1.2000)</version>
     </dependency>
+      <dependency>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>connect-api</artifactId>
+          <version>${connect.api.version}</version>
+          <scope>provided</scope>
+      </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
       <version>[0.2.33,0.2.1000)</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+          <version>2.9.0</version>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
       <version>[0.2.33,0.2.1000)</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>3.12.0</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -48,6 +48,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
         .field("partition", Schema.INT64_SCHEMA)
         .field("value", r.valueSchema())
         .field("topic", Schema.STRING_SCHEMA)
+        .field("headers", Schema.STRING_SCHEMA)
         .field("timestamp", Schema.INT64_SCHEMA);
     Struct value = new Struct(schema)
         .put("key", r.key())
@@ -55,7 +56,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
         .put("value", r.value())
         .put("topic", r.topic())
         .put("timestamp", r.timestamp());
-    return r.newRecord(r.topic(), r.kafkaPartition(), null, null, schema, value, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, value, r.timestamp());
   }
 
   @SuppressWarnings("unchecked")
@@ -71,7 +72,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     archiveValue.put("partition", r.kafkaPartition());
     archiveValue.put("timestamp", r.timestamp());
 
-    return r.newRecord(r.topic(), r.kafkaPartition(), null, null, null, archiveValue, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, archiveValue, r.timestamp());
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -53,7 +53,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
         .put("value", r.value())
         .put("topic", r.topic())
         .put("timestamp", r.timestamp());
-    return r.newRecord(r.topic(), r.kafkaPartition(), null, null, schema, value, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, value, r.timestamp());
   }
 
   @SuppressWarnings("unchecked")
@@ -68,7 +68,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     archiveValue.put("topic", r.topic());
     archiveValue.put("timestamp", r.timestamp());
 
-    return r.newRecord(r.topic(), r.kafkaPartition(), null, null, null, archiveValue, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, archiveValue, r.timestamp());
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -59,15 +59,11 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, value, r.timestamp());
   }
 
-  @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
-
     final Map<String, Object> archiveValue = new HashMap<>();
 
-    final Map<String, Object> value = (Map<String, Object>) r.value();
-
     archiveValue.put("key", r.key());
-    archiveValue.put("value", value);
+    archiveValue.put("value", r.value());
     archiveValue.put("topic", r.topic());
     archiveValue.put("partition", r.kafkaPartition());
     archiveValue.put("timestamp", r.timestamp());

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -53,10 +53,11 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     Struct value = new Struct(schema)
         .put("key", r.key())
         .put("partition", r.kafkaPartition())
+        .put("headers", r.headers())
         .put("value", r.value())
         .put("topic", r.topic())
         .put("timestamp", r.timestamp());
-    return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, value, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, value, r.timestamp(), r.headers());
   }
 
   @SuppressWarnings("unchecked")
@@ -67,12 +68,13 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     final Map<String, Object> value = (Map<String, Object>) r.value();
 
     archiveValue.put("key", r.key());
+    archiveValue.put("partition", r.kafkaPartition());
+    archiveValue.put("headers", r.headers());
     archiveValue.put("value", value);
     archiveValue.put("topic", r.topic());
-    archiveValue.put("partition", r.kafkaPartition());
     archiveValue.put("timestamp", r.timestamp());
 
-    return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, archiveValue, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, archiveValue, r.timestamp(), r.headers());
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -24,8 +24,11 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.apache.commons.lang3.SerializationUtils.serialize;
 
 @Description("The Archive transformation is used to help preserve all of the data for a message when archived to S3.")
 @DocumentationNote("This transform works by copying the key, value, topic, and timestamp to new record where this is all " +
@@ -51,7 +54,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
         .field("headers", Schema.STRING_SCHEMA)
         .field("timestamp", Schema.INT64_SCHEMA);
     Struct value = new Struct(schema)
-        .put("key", r.key())
+        .put("key", serialize((Serializable) r.key()))
         .put("partition", r.kafkaPartition())
         .put("value", r.value())
         .put("topic", r.topic())
@@ -62,7 +65,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
   private R applySchemaless(R r) {
     final Map<String, Object> archiveValue = new HashMap<>();
 
-    archiveValue.put("key", r.key());
+    archiveValue.put("key", serialize((Serializable) r.key()));
     archiveValue.put("value", r.value());
     archiveValue.put("topic", r.topic());
     archiveValue.put("partition", r.kafkaPartition());
@@ -85,4 +88,6 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
   public void configure(Map<String, ?> map) {
 
   }
+
+
 }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -67,6 +67,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     archiveValue.put("key", r.key());
     archiveValue.put("value", value);
     archiveValue.put("topic", r.topic());
+    archiveValue.put("partition", r.kafkaPartition());
     archiveValue.put("timestamp", r.timestamp());
 
     return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, archiveValue, r.timestamp());

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -48,13 +48,15 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     final Schema schema = SchemaBuilder.struct()
         .name("com.github.jcustenborder.kafka.connect.archive.Storage")
         .field("key", r.keySchema())
+        .field("key_string", Schema.STRING_SCHEMA)
         .field("partition", Schema.INT64_SCHEMA)
         .field("value", r.valueSchema())
         .field("topic", Schema.STRING_SCHEMA)
         .field("headers", Schema.STRING_SCHEMA)
         .field("timestamp", Schema.INT64_SCHEMA);
     Struct value = new Struct(schema)
-        .put("key", serialize((Serializable) r.key()))
+        .put("key", r.key())
+        .put("key_string", String.valueOf(r.key()).replaceAll("[^\\x00-\\x7F]", ""))
         .put("partition", r.kafkaPartition())
         .put("value", r.value())
         .put("topic", r.topic())
@@ -65,7 +67,8 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
   private R applySchemaless(R r) {
     final Map<String, Object> archiveValue = new HashMap<>();
 
-    archiveValue.put("key", serialize((Serializable) r.key()));
+    archiveValue.put("key", r.key());
+    archiveValue.put("key_string", String.valueOf(r.key()).replaceAll("[^\\x00-\\x7F]", ""));
     archiveValue.put("value", r.value());
     archiveValue.put("topic", r.topic());
     archiveValue.put("partition", r.kafkaPartition());

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -55,7 +55,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
         .put("value", r.value())
         .put("topic", r.topic())
         .put("timestamp", r.timestamp());
-    return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, value, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), null, null, schema, value, r.timestamp());
   }
 
   @SuppressWarnings("unchecked")
@@ -71,7 +71,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     archiveValue.put("partition", r.kafkaPartition());
     archiveValue.put("timestamp", r.timestamp());
 
-    return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, archiveValue, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), null, null, null, archiveValue, r.timestamp());
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -24,6 +24,9 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
 
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,14 +49,22 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
         .name("com.github.jcustenborder.kafka.connect.archive.Storage")
         .field("key", r.keySchema())
         .field("key_string", Schema.STRING_SCHEMA)
+        .field("timestamp_year", Schema.INT8_SCHEMA)
+        .field("timestamp_month", Schema.INT8_SCHEMA)
+        .field("timestamp_day", Schema.INT8_SCHEMA)
         .field("partition", Schema.INT64_SCHEMA)
         .field("value", r.valueSchema())
         .field("topic", Schema.STRING_SCHEMA)
         .field("headers", Schema.STRING_SCHEMA)
         .field("timestamp", Schema.INT64_SCHEMA);
+    Calendar recordDate = new GregorianCalendar();
+    recordDate.setTimeInMillis(r.timestamp());
     Struct value = new Struct(schema)
         .put("key", r.key())
         .put("key_string", String.valueOf(r.key()).replaceAll("[^\\x00-\\x7F]", ""))
+        .put("timestamp_year", recordDate.get(Calendar.YEAR))
+        .put("timestamp_month", recordDate.get(Calendar.MONTH))
+        .put("timestamp_day", recordDate.get(Calendar.DAY_OF_MONTH))
         .put("partition", r.kafkaPartition())
         .put("value", r.value())
         .put("topic", r.topic())
@@ -64,8 +75,14 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
   private R applySchemaless(R r) {
     final Map<String, Object> archiveValue = new HashMap<>();
 
+    Calendar recordDate = new GregorianCalendar();
+    recordDate.setTimeInMillis(r.timestamp());
+
     archiveValue.put("key", r.key());
     archiveValue.put("key_string", String.valueOf(r.key()).replaceAll("[^\\x00-\\x7F]", ""));
+    archiveValue.put("timestamp_year", recordDate.get(Calendar.YEAR));
+    archiveValue.put("timestamp_month", recordDate.get(Calendar.MONTH));
+    archiveValue.put("timestamp_day", recordDate.get(Calendar.DAY_OF_MONTH));
     archiveValue.put("value", r.value());
     archiveValue.put("topic", r.topic());
     archiveValue.put("partition", r.kafkaPartition());

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -53,11 +53,10 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     Struct value = new Struct(schema)
         .put("key", r.key())
         .put("partition", r.kafkaPartition())
-        .put("headers", r.headers())
         .put("value", r.value())
         .put("topic", r.topic())
         .put("timestamp", r.timestamp());
-    return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, value, r.timestamp(), r.headers());
+    return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, value, r.timestamp());
   }
 
   @SuppressWarnings("unchecked")
@@ -68,13 +67,12 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     final Map<String, Object> value = (Map<String, Object>) r.value();
 
     archiveValue.put("key", r.key());
-    archiveValue.put("partition", r.kafkaPartition());
-    archiveValue.put("headers", r.headers());
     archiveValue.put("value", value);
     archiveValue.put("topic", r.topic());
+    archiveValue.put("partition", r.kafkaPartition());
     archiveValue.put("timestamp", r.timestamp());
 
-    return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, archiveValue, r.timestamp(), r.headers());
+    return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, archiveValue, r.timestamp());
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -45,6 +45,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
     final Schema schema = SchemaBuilder.struct()
         .name("com.github.jcustenborder.kafka.connect.archive.Storage")
         .field("key", r.keySchema())
+        .field("partition", Schema.INT64_SCHEMA)
         .field("value", r.valueSchema())
         .field("topic", Schema.STRING_SCHEMA)
         .field("timestamp", Schema.INT64_SCHEMA);

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -24,7 +24,6 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
 
-import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashMap;

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -24,11 +24,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.apache.commons.lang3.SerializationUtils.serialize;
 
 @Description("The Archive transformation is used to help preserve all of the data for a message when archived to S3.")
 @DocumentationNote("This transform works by copying the key, value, topic, and timestamp to new record where this is all " +

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/Archive.java
@@ -50,6 +50,7 @@ public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
         .field("timestamp", Schema.INT64_SCHEMA);
     Struct value = new Struct(schema)
         .put("key", r.key())
+        .put("partition", r.kafkaPartition())
         .put("value", r.value())
         .put("topic", r.topic())
         .put("timestamp", r.timestamp());

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -19,7 +19,6 @@ package com.github.jcustenborder.kafka.connect.archive;
 import com.github.jcustenborder.kafka.connect.utils.config.Description;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.transforms.Transformation;

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> {
   @Override
   public R apply(R r) {
-      return applySchemaless(r);
+    return applySchemaless(r);
   }
   @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
@@ -39,16 +39,16 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
     System.out.println("before");
     System.out.println(value);
     R record = r.newRecord(
-      value.get("topic").toString(),
-      value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
-      null,
-      value.get("key"),
-      null,
-      value.get("value"),
-      Long.parseLong(value.get("timestamp").toString())
+        value.get("topic").toString(),
+        value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
+        null,
+        value.get("key"),
+        null,
+        value.get("value"),
+        Long.parseLong(value.get("timestamp").toString())
     );
-      System.out.println("record");
-      System.out.println(record);
+    System.out.println("record");
+    System.out.println(record);
     return record;
   }
 

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -42,27 +42,27 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
     // TODO: we might need to archive also the schema
     final Map<String, Object> value = (Map<String, Object>) r.value();
     return r.newRecord(
-            value.get("topic").toString(),
-            Integer.parseInt(value.get("partition").toString()),
-            null,
-            value.get("key"),
-            null,
-            value.get("value"),
-            Long.parseLong(value.get("timestamp").toString())
+      value.get("topic").toString(),
+      Integer.parseInt(value.get("partition").toString()),
+      null,
+      value.get("key"),
+      null,
+      value.get("value"),
+      Long.parseLong(value.get("timestamp").toString())
     );
   }
     @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
     final Map<String, Object> value = (Map<String, Object>) r.value();
-      return r.newRecord(
-              value.get("topic").toString(),
-              Integer.parseInt(value.get("partition").toString()),
-              null,
-              value.get("key"),
-              null,
-              value.get("value"),
-              Long.parseLong(value.get("timestamp").toString())
-      );
+    return r.newRecord(
+      value.get("topic").toString(),
+      Integer.parseInt(value.get("partition").toString()),
+      null,
+      value.get("key"),
+      null,
+      value.get("value"),
+      Long.parseLong(value.get("timestamp").toString())
+    );
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -39,7 +39,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
     System.out.println("before");
     System.out.println(value);
     R record = r.newRecord(
-        value.get("topic").toString(),
+        null,
         value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
         null,
         value.get("key"),

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -20,7 +20,6 @@ import com.github.jcustenborder.kafka.connect.utils.config.Description;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.transforms.Transformation;
 
 import java.util.Map;
@@ -39,13 +38,12 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
     final Map<String, Object> value = (Map<String, Object>) r.value();
     return r.newRecord(
         r.topic(),
-        value.getOrDefault("partition", null) != null ? Integer.parseInt(value.get("partition").toString()) : null,
+        value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
         null,
         value.get("key"),
         null,
         value.get("value"),
-        Long.parseLong(value.get("timestamp").toString()),
-        (Headers) value.getOrDefault("headers", null)
+        Long.parseLong(value.get("timestamp").toString())
     );
   }
 

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -36,9 +36,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
   @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
     final Map<String, Object> value = (Map<String, Object>) r.value();
-    System.out.println("before");
-    System.out.println(value);
-    R record = r.newRecord(
+    return r.newRecord(
         r.topic(),
         value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
         null,
@@ -47,9 +45,6 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
         value.get("value"),
         Long.parseLong(value.get("timestamp").toString())
     );
-    System.out.println("record");
-    System.out.println(record);
-    return record;
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -18,7 +18,6 @@ package com.github.jcustenborder.kafka.connect.archive;
 
 import com.github.jcustenborder.kafka.connect.utils.config.Description;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
-import com.google.gson.Gson;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.transforms.Transformation;
@@ -30,12 +29,6 @@ import java.util.Map;
     "contained in the value of the message. This will allow connectors like Confluent's S3 connector to properly unarchive " +
     "the record.")
 public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> {
-  private final Gson gson;
-
-  public UnArchive() {
-    this.gson = new Gson();  // Set the initial value for the class attribute x
-  }
-
   @Override
   public R apply(R r) {
     if (r.valueSchema() == null) {
@@ -47,7 +40,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
   @SuppressWarnings("unchecked")
   private R applyWithSchema(R r) {
     // TODO: we might need to archive also the schema
-    final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Map.class) : r.value());
+    final Map<String, Object> value = (Map<String, Object>) r.value();
     return r.newRecord(
       value.get("topic").toString(),
       value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
@@ -60,10 +53,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
   }
   @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
-    System.out.println(r.value());
-    System.out.println(r.value().toString());
-    final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Map.class) : r.value());
-    System.out.println(value);
+    final Map<String, Object> value = (Map<String, Object>) r.value();
     return r.newRecord(
       value.get("topic").toString(),
       value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -61,7 +61,10 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
   }
   @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
+    System.out.println(r.value());
+    System.out.println(r.value().toString());
     final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Map.class) : r.value());
+    System.out.println(value);
     return r.newRecord(
       value.get("topic").toString(),
       value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @DocumentationNote("This transform works by copying the key, value, topic, and timestamp to new record where this is all " +
     "contained in the value of the message. This will allow connectors like Confluent's S3 connector to properly unarchive " +
     "the record.")
-public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
+public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> {
   @Override
   public R apply(R r) {
     if (r.valueSchema() == null) {

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -50,7 +50,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
     final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Object.class) : r.value());
     return r.newRecord(
       value.get("topic").toString(),
-      Integer.parseInt(value.get("partition").toString()),
+      value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
       null,
       value.get("key"),
       null,
@@ -63,7 +63,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
     final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Object.class) : r.value());
     return r.newRecord(
       value.get("topic").toString(),
-      Integer.parseInt(value.get("partition").toString()),
+      value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
       null,
       value.get("key"),
       null,

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -31,30 +31,14 @@ import java.util.Map;
 public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> {
   @Override
   public R apply(R r) {
-    if (r.valueSchema() == null) {
       return applySchemaless(r);
-    } else {
-      return applyWithSchema(r);
-    }
-  }
-  @SuppressWarnings("unchecked")
-  private R applyWithSchema(R r) {
-    // TODO: we might need to archive also the schema
-    final Map<String, Object> value = (Map<String, Object>) r.value();
-    return r.newRecord(
-      value.get("topic").toString(),
-      value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
-      null,
-      value.get("key"),
-      null,
-      value.get("value"),
-      Long.parseLong(value.get("timestamp").toString())
-    );
   }
   @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
     final Map<String, Object> value = (Map<String, Object>) r.value();
-    return r.newRecord(
+    System.out.println("before");
+    System.out.println(value);
+    R record = r.newRecord(
       value.get("topic").toString(),
       value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
       null,
@@ -63,6 +47,9 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
       value.get("value"),
       Long.parseLong(value.get("timestamp").toString())
     );
+      System.out.println("record");
+      System.out.println(record);
+    return record;
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -37,7 +37,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
       return applyWithSchema(r);
     }
   }
-    @SuppressWarnings("unchecked")
+  @SuppressWarnings("unchecked")
   private R applyWithSchema(R r) {
     // TODO: we might need to archive also the schema
     final Map<String, Object> value = (Map<String, Object>) r.value();
@@ -51,7 +51,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
       Long.parseLong(value.get("timestamp").toString())
     );
   }
-    @SuppressWarnings("unchecked")
+  @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
     final Map<String, Object> value = (Map<String, Object>) r.value();
     return r.newRecord(

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -20,12 +20,8 @@ import com.github.jcustenborder.kafka.connect.utils.config.Description;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
 
-import java.util.HashMap;
 import java.util.Map;
 
 @Description("The UnArchive transformation is used to unarchive data from S3 into the original format.")

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -39,7 +39,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
     System.out.println("before");
     System.out.println(value);
     R record = r.newRecord(
-        null,
+        r.topic(),
         value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
         null,
         value.get("key"),

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -24,6 +24,9 @@ import org.apache.kafka.connect.transforms.Transformation;
 
 import java.util.Map;
 
+import static org.apache.commons.lang3.SerializationUtils.deserialize;
+
+
 @Description("The UnArchive transformation is used to unarchive data from S3 into the original format.")
 @DocumentationNote("This transform works by copying the key, value, topic, and timestamp to new record where this is all " +
     "contained in the value of the message. This will allow connectors like Confluent's S3 connector to properly unarchive " +
@@ -40,7 +43,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
         r.topic(),
         value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
         null,
-        value.get("key"),
+        deserialize((byte[]) value.get("key")),
         null,
         value.get("value"),
         Long.parseLong(value.get("timestamp").toString())

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -20,6 +20,7 @@ import com.github.jcustenborder.kafka.connect.utils.config.Description;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.transforms.Transformation;
 
 import java.util.Map;
@@ -38,12 +39,13 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
     final Map<String, Object> value = (Map<String, Object>) r.value();
     return r.newRecord(
         r.topic(),
-        value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
+        value.getOrDefault("partition", null) != null ? Integer.parseInt(value.get("partition").toString()) : null,
         null,
         value.get("key"),
         null,
         value.get("value"),
-        Long.parseLong(value.get("timestamp").toString())
+        Long.parseLong(value.get("timestamp").toString()),
+        (Headers) value.getOrDefault("headers", null)
     );
   }
 

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright © 2022 Iosif Nicolae (iosif@bringes.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.jcustenborder.kafka.connect.archive;
+
+import com.github.jcustenborder.kafka.connect.utils.config.Description;
+import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Description("The UnArchive transformation is used to unarchive data from S3 into the original format.")
+@DocumentationNote("This transform works by copying the key, value, topic, and timestamp to new record where this is all " +
+    "contained in the value of the message. This will allow connectors like Confluent's S3 connector to properly unarchive " +
+    "the record.")
+public class Archive<R extends ConnectRecord<R>> implements Transformation<R> {
+  @Override
+  public R apply(R r) {
+    if (r.valueSchema() == null) {
+      return applySchemaless(r);
+    } else {
+      return applyWithSchema(r);
+    }
+  }
+
+  private R applyWithSchema(R r) {
+    // TODO: we might need to archive also the schema
+    return r.newRecord(r.value().get("topic"), r.value().get("partition"), null, r.value().get("key"), null, r.value().get("value"), r.value().get("timestamp"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private R applySchemaless(R r) {
+    return r.newRecord(r.value().get("topic"), r.value().get("partition"), null, r.value().get("key"), null, r.value().get("value"), r.value().get("timestamp"));
+  }
+
+  @Override
+  public ConfigDef config() {
+    return new ConfigDef();
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+
+  }
+}

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -37,15 +37,32 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
       return applyWithSchema(r);
     }
   }
-
+    @SuppressWarnings("unchecked")
   private R applyWithSchema(R r) {
     // TODO: we might need to archive also the schema
-    return r.newRecord(r.value().get("topic"), r.value().get("partition"), null, r.value().get("key"), null, r.value().get("value"), r.value().get("timestamp"));
+    final Map<String, Object> value = (Map<String, Object>) r.value();
+    return r.newRecord(
+            value.get("topic").toString(),
+            Integer.parseInt(value.get("partition").toString()),
+            null,
+            value.get("key"),
+            null,
+            value.get("value"),
+            Long.parseLong(value.get("timestamp").toString())
+    );
   }
-
-  @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
-    return r.newRecord(r.value().get("topic"), r.value().get("partition"), null, r.value().get("key"), null, r.value().get("value"), r.value().get("timestamp"));
+    final Map<String, Object> value = (Map<String, Object>) r.value();
+      return r.newRecord(
+              value.get("topic").toString(),
+              Integer.parseInt(value.get("partition").toString()),
+              null,
+              value.get("key"),
+              null,
+              value.get("value"),
+              Long.parseLong(value.get("timestamp").toString())
+      );
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -18,6 +18,7 @@ package com.github.jcustenborder.kafka.connect.archive;
 
 import com.github.jcustenborder.kafka.connect.utils.config.Description;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
+import com.google.gson.Gson;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.transforms.Transformation;
@@ -29,6 +30,12 @@ import java.util.Map;
     "contained in the value of the message. This will allow connectors like Confluent's S3 connector to properly unarchive " +
     "the record.")
 public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> {
+  private final Gson gson;
+
+  public UnArchive() {
+    this.gson = new Gson();  // Set the initial value for the class attribute x
+  }
+
   @Override
   public R apply(R r) {
     if (r.valueSchema() == null) {
@@ -40,7 +47,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
   @SuppressWarnings("unchecked")
   private R applyWithSchema(R r) {
     // TODO: we might need to archive also the schema
-    final Map<String, Object> value = (Map<String, Object>) r.value();
+    final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Object.class) : r.value());
     return r.newRecord(
       value.get("topic").toString(),
       Integer.parseInt(value.get("partition").toString()),
@@ -53,7 +60,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
   }
   @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
-    final Map<String, Object> value = (Map<String, Object>) r.value();
+    final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Object.class) : r.value());
     return r.newRecord(
       value.get("topic").toString(),
       Integer.parseInt(value.get("partition").toString()),

--- a/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/archive/UnArchive.java
@@ -19,6 +19,7 @@ package com.github.jcustenborder.kafka.connect.archive;
 import com.github.jcustenborder.kafka.connect.utils.config.Description;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.transforms.Transformation;
@@ -47,7 +48,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
   @SuppressWarnings("unchecked")
   private R applyWithSchema(R r) {
     // TODO: we might need to archive also the schema
-    final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Object.class) : r.value());
+    final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Map.class) : r.value());
     return r.newRecord(
       value.get("topic").toString(),
       value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,
@@ -60,7 +61,7 @@ public class UnArchive<R extends ConnectRecord<R>> implements Transformation<R> 
   }
   @SuppressWarnings("unchecked")
   private R applySchemaless(R r) {
-    final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Object.class) : r.value());
+    final Map<String, Object> value = (Map<String, Object>) (r.value() instanceof String ? this.gson.fromJson(r.value().toString(), Map.class) : r.value());
     return r.newRecord(
       value.get("topic").toString(),
       value.get("partition") != null ? Integer.parseInt(value.get("partition").toString()) : null,


### PR DESCRIPTION
The UnArchiver is useful to backup all kafka messages to S3 and then restore the backup in another topic.


Here is a guide on how to do this:
1. Use the following S3 Sink & Source Connector -  https://github.com/iosifnicolae2/stream-reactor
2. Include the following S3 Connector plugin - https://github.com/iosifnicolae2/kafka-connect-transform-archive
   - you can use this [Dockerfile](https://github.com/iosifnicolae2/kafka-connect-transform-archive/blob/master/Dockerfile) to build the plugin and include it in your Kafka Connector
3. Configure your Sink connector using:
```
"connect.s3.kcql" : "insert into <bucket_name>:<path> select * from <topic> STOREAS `JSON` WITH_FLUSH_INTERVAL=60 WITH_FLUSH_COUNT=1000"
"transforms" : "archiveRowForS3",
"transforms.archiveRowForS3.type" : "com.github.jcustenborder.kafka.connect.archive.Archive",
```
4. Configure your Source connector using:
```
"connect.s3.kcql" : "insert into <topic> select * from <bucket_name>:<path>  BATCH = 5 STOREAS `JSON` LIMIT 1000"
"transforms" : "unArchiveRowFromS3",
"transforms.unArchiveRowFromS3.type" : "com.github.jcustenborder.kafka.connect.archive.UnArchive",
```
